### PR TITLE
revert: interaction route

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -15,7 +15,7 @@ const app = new Elysia()
 
     return 'Commands installed'
   })
-  .post('/', ({ request }) => handleRequest(request, commands, components, events, config), {
+  .post('/discord/handle-interaction', ({ request }) => handleRequest(request, commands, components, events, config), {
     parse: 'none',
   })
   .listen(3000)


### PR DESCRIPTION
That was an accident earlier, my testing bot uses the `/` route for interactions, so I'd just been fixing it and didn't intend to commit that.