### PR TITLE
feat: resume and trigger jobs on startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-bun run server/jobs.ts &
 bun run server/main.ts &
 NITRO_PORT=3001 bun run client/server/index.mjs &
 wait

--- a/server/main.ts
+++ b/server/main.ts
@@ -2,6 +2,7 @@ import { cors } from '@elysiajs/cors'
 import { handleRequest } from 'dressed/server'
 import { Elysia } from 'elysia'
 import { commands, components, config, events } from './.dressed'
+import { startJobs } from './jobs'
 import { auth } from './lib/auth'
 import { adminRoutes } from './routes/admin'
 import { logger } from './utilities/logger'
@@ -9,6 +10,10 @@ import { overrideConsole } from './utilities/overrides'
 
 // Have to do this to hijack Dressed's logs and pipe them to pino/LOKI
 overrideConsole()
+
+// Start jobs and trigger
+const triggerOnStart = process.env.NODE_ENV === 'production'
+startJobs(triggerOnStart)
 
 export const app = new Elysia()
   .onError((err) => {


### PR DESCRIPTION
## Description
All jobs start paused, but resumed manually. In production it's triggered immediately to ensure production is always up to date.

Closes #69 

## Checklist

- [x] Associated TODOs are resolved
- [x] Biome check passes
- [x] **Database migrations are generated**
- [x] Docker build passes (`docker build --pull -t torkin-test .`)
